### PR TITLE
[feat] Further summary graphic improvements

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -540,7 +540,7 @@ def addPlay(game, playSummary, forceDriveEndType):
 		else:
 			summary.result = drive[-1].actualResult
 
-		field = drive_graphic.makeField(drive)
+		field = drive_graphic.makeField(plays=drive)
 		driveImageUrl = drive_graphic.uploadField(field, game.thread, str(len(game.status.plays) - 2))
 		game.status.drives.append({'summary': summary, 'url': driveImageUrl})
 		return f"Drive: [{str(summary)}]({driveImageUrl})"


### PR DESCRIPTION
- Consolidate color settings
  - Line of scrimmage is now the color of the possessing team (will be grey for both teams until home/away colors are implemented in production)
- Distinguish made (yellow) vs missed (black) PATs and field goals
- Show turnovers (orange)

Examples:

Drive ending with a TD and then a PAT:
![image](https://github.com/user-attachments/assets/5fc47c9f-3564-45dc-9696-121c0fe48fa0)

Drive ending with a made field goal:
![image](https://github.com/user-attachments/assets/e424ee26-8319-46f8-96ec-e1a8f9a98bb0)

Drive ending with a missed field goal:
![image](https://github.com/user-attachments/assets/edbec36e-5cf5-49e4-adea-0d0001858258)

Drive ending with a turnover TD and following PAT for opposite team:
![image](https://github.com/user-attachments/assets/d5684a7c-5fdf-460c-9e32-163abff5cb8b)

(Super weird one) Drive continued with a self-recovered punt and then ending with a made field goal:
![image](https://github.com/user-attachments/assets/7703eb68-55f0-435f-bb47-65ec28431853)
